### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install via `pip`:
 ### Contributors
 
 I would like to thank the following people for their contribution in issues, algorithms and code snippets
-which have helepd improve ChainConsumer:
+which have helped improve ChainConsumer:
 
 * Chris Davis (check out https://github.com/cpadavis/preliminize)
 * Joe Zuntz

--- a/chainconsumer/chain.py
+++ b/chainconsumer/chain.py
@@ -278,11 +278,11 @@ class ChainConsumer(object):
             than colours, you *will* get the rainbow colour spectrum. If you only pass
             one colour, all chains are set to this colour. This probably won't look good.
         linestyles : str|list[str], optional
-            Provide a list of line styles to plot the contours and marginalsied
+            Provide a list of line styles to plot the contours and marginalised
             distributions with. By default, this will become a list of solid lines. If a
             string is passed instead of a list, this style is used for all chains.
         linewidths : float|list[float], optional
-            Provide a list of line widths to plot the contours and marginalsied
+            Provide a list of line widths to plot the contours and marginalised
             distributions with. By default, this is a width of 1. If a float
             is passed instead of a list, this width is used for all chains.
         kde : bool|float|list[bool|float], optional
@@ -353,7 +353,7 @@ class ChainConsumer(object):
         legend_color_text : bool, optional
             Whether to colour the legend text.
         watermark_text_kwargs : dict, optional
-            Options to pass to the fontdict propery when generating text for the watermark.
+            Options to pass to the fontdict property when generating text for the watermark.
             
         Returns
         -------
@@ -658,7 +658,7 @@ class ChainConsumer(object):
 
         This method might be useful if, for example, your chain was made using
         MCMC with 4 walkers. To check the sampling of all 4 walkers agree, you could
-        call this to get a ChainConumser instance with one chain for ech of the
+        call this to get a ChainConsumer instance with one chain for ech of the
         four walks. If you then plot, hopefully all four contours
         you would see agree.
 

--- a/chainconsumer/helpers.py
+++ b/chainconsumer/helpers.py
@@ -21,12 +21,12 @@ def get_bins(chains):
     return proposal
 
 
-def get_smoothed_bins(smooth, bins, data, weight, marginalsied=True, plot=False):
+def get_smoothed_bins(smooth, bins, data, weight, marginalised=True, plot=False):
     minv, maxv = get_extents(data, weight, plot=plot)
     if smooth is None or not smooth or smooth == 0:
         return np.linspace(minv, maxv, int(bins)), 0
     else:
-        return np.linspace(minv, maxv, int((2 if marginalsied else 2) * smooth * bins)), smooth
+        return np.linspace(minv, maxv, int((2 if marginalised else 2) * smooth * bins)), smooth
 
 
 def get_grid_bins(data):

--- a/chainconsumer/kde.py
+++ b/chainconsumer/kde.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 class MegKDE(object):
-    """ Matched Elliptical Gaussian Kernel Desntiy Estimator
+    """ Matched Elliptical Gaussian Kernel Density Estimator
     
     Adapted from the algorithm specified in the BAMBIS's model specified Wolf 2017
     to support weighted samples.
@@ -45,7 +45,7 @@ class MegKDE(object):
         self.sigma = 2.0 * factor * np.power(self.num_points, -1. / (4 + self.num_dim))  # Starting sigma (bw) of Gauss
         self.sigma_fact = -0.5 / (self.sigma * self.sigma)
 
-        # Cant get normed probs to work atm, turning off for now as I dont need normed pdfs for contours
+        # Cant get normed probs to work atm, turning off for now as I don't need normed pdfs for contours
         # self.norm = np.product(np.diagonal(self.A)) * (2 * np.pi) ** (-0.5 * self.num_dim)  # prob norm
         # self.scaling = np.power(self.norm * self.sigma, -self.num_dim)
 

--- a/chainconsumer/plotter.py
+++ b/chainconsumer/plotter.py
@@ -70,7 +70,7 @@ class Plotter(object):
         if legend is None:
             legend = len(chains) > 1
 
-        # If no chains have names, dont plot the legend
+        # If no chains have names, don't plot the legend
         legend = legend and len([n for n in names if n]) > 0
 
         # Calculate cmap extents
@@ -309,7 +309,7 @@ class Plotter(object):
         Parameters
         ----------
         parameters : list[str]|int, optional
-            Specifiy a subset of parameters to plot. If not set, all parameters are plotted.
+            Specify a subset of parameters to plot. If not set, all parameters are plotted.
             If an integer is given, only the first so many parameters are plotted.
         truth : list[float]|dict[str], optional
             A list of truth values corresponding to parameters, or a dictionary of
@@ -413,7 +413,7 @@ class Plotter(object):
         Parameters
         ----------
         parameters : list[str]|int, optional
-            Specifiy a subset of parameters to plot. If not set, all parameters are plotted.
+            Specify a subset of parameters to plot. If not set, all parameters are plotted.
             If an integer is given, only the first so many parameters are plotted.
         truth : list[float]|dict[str], optional
             A list of truth values corresponding to parameters, or a dictionary of
@@ -718,8 +718,8 @@ class Plotter(object):
             binsy = get_grid_bins(y)
             hist, x_bins, y_bins = np.histogram2d(x, y, bins=[binsx, binsy], weights=w)
         else:
-            binsx, smooth = get_smoothed_bins(smooth, bins, x, w, marginalsied=False)
-            binsy, _ = get_smoothed_bins(smooth, bins, y, w, marginalsied=False)
+            binsx, smooth = get_smoothed_bins(smooth, bins, x, w, marginalised=False)
+            binsy, _ = get_smoothed_bins(smooth, bins, y, w, marginalised=False)
             hist, x_bins, y_bins = np.histogram2d(x, y, bins=[binsx, binsy], weights=w)
 
         colours = self._scale_colours(colour, len(levels), shade_gradient)


### PR DESCRIPTION
  * `marginalsied` -> `marginalised`
  * `propery` -> `property`
  * `ChainConumser` -> `ChainConsumer`
  * `desntiy` -> `destiny`
  * `dont` -> `don't`
  * `specifiy` -> `specify`
  * `helepd` -> `helped`
