### PR TITLE
FastKDE

### DIFF
--- a/chainconsumer/analysis.py
+++ b/chainconsumer/analysis.py
@@ -275,7 +275,6 @@ class Analysis(object):
             # area = simps(ys, x=kde_xs)
             # ys = ys / area
             # ys = interp1d(kde_xs, ys, kind="linear")(xs)
-            
             ys, kde_xs = fastKDE.pdf(data)
             ys = interp1d(kde_xs, ys, kind="linear", bounds_error=False, fill_value=0.)(xs)
         else:

--- a/chainconsumer/analysis.py
+++ b/chainconsumer/analysis.py
@@ -5,6 +5,7 @@ from scipy.interpolate import interp1d
 from scipy.ndimage.filters import gaussian_filter
 from .helpers import get_smoothed_bins, get_grid_bins, get_latex_table_frame
 from .kde import MegKDE
+from fastkde import fastKDE
 
 
 class Analysis(object):
@@ -269,11 +270,14 @@ class Analysis(object):
             hist = gaussian_filter(hist, smooth, mode=self.parent._gauss_mode)
         kde = chain.config["kde"]
         if kde:
-            kde_xs = np.linspace(edge_centers[0], edge_centers[-1], max(200, int(bins.max())))
-            ys = MegKDE(data, chain.weights, factor=kde).evaluate(kde_xs)
-            area = simps(ys, x=kde_xs)
-            ys = ys / area
-            ys = interp1d(kde_xs, ys, kind="linear")(xs)
+            # kde_xs = np.linspace(edge_centers[0], edge_centers[-1], max(200, int(bins.max())))
+            # ys = MegKDE(data, chain.weights, factor=kde).evaluate(kde_xs)
+            # area = simps(ys, x=kde_xs)
+            # ys = ys / area
+            # ys = interp1d(kde_xs, ys, kind="linear")(xs)
+            
+            ys, kde_xs = fastKDE.pdf(data)
+            ys = interp1d(kde_xs, ys, kind="linear", bounds_error=False, fill_value=0.)(xs)
         else:
             ys = interp1d(edge_centers, hist, kind="linear")(xs)
         cs = ys.cumsum()

--- a/chainconsumer/plotter.py
+++ b/chainconsumer/plotter.py
@@ -4,12 +4,13 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator, ScalarFormatter
 from matplotlib.textpath import TextPath
 from numpy import meshgrid
-from scipy.interpolate import interp1d
+from scipy.interpolate import interp1d, interp2d
 from scipy.ndimage import gaussian_filter
 from scipy.stats import norm
 
 from .helpers import get_extents, get_smoothed_bins, get_grid_bins
 from .kde import MegKDE
+from fastkde import fastKDE
 
 
 class Plotter(object):
@@ -905,13 +906,32 @@ class Plotter(object):
         x_centers = 0.5 * (x_bins[:-1] + x_bins[1:])
         y_centers = 0.5 * (y_bins[:-1] + y_bins[1:])
         if kde:
+            # nn = x_centers.size * 2  # Double samples for KDE because smooth
+            # x_centers = np.linspace(x_bins.min(), x_bins.max(), nn)
+            # y_centers = np.linspace(y_bins.min(), y_bins.max(), nn)
+            # xx, yy = meshgrid(x_centers, y_centers, indexing='ij')
+            # coords = np.vstack((xx.flatten(), yy.flatten())).T
+            # data = np.vstack((x, y)).T
+            # hist = MegKDE(data, w, kde).evaluate(coords).reshape((nn, nn))
+            
             nn = x_centers.size * 2  # Double samples for KDE because smooth
             x_centers = np.linspace(x_bins.min(), x_bins.max(), nn)
             y_centers = np.linspace(y_bins.min(), y_bins.max(), nn)
             xx, yy = meshgrid(x_centers, y_centers, indexing='ij')
             coords = np.vstack((xx.flatten(), yy.flatten())).T
-            data = np.vstack((x, y)).T
-            hist = MegKDE(data, w, kde).evaluate(coords).reshape((nn, nn))
+            
+            print coords.shape
+            print xx.shape
+            print xx.flatten().shape
+            
+            hist_kde, (x_centers_kde, y_centers_kde) = fastKDE.pdf(x,y)
+            
+            print hist_kde.shape
+            print x_centers_kde.shape
+            
+            hist = interp2d(x_centers_kde, y_centers_kde, hist_kde, kind='linear', bounds_error=False, fill_value=0.)(x_centers, y_centers).reshape((nn, nn))
+            
+            
         elif smooth:
             hist = gaussian_filter(hist, smooth, mode=self.parent._gauss_mode)
         hist[hist == 0] = 1E-16

--- a/chainconsumer/plotter.py
+++ b/chainconsumer/plotter.py
@@ -906,31 +906,15 @@ class Plotter(object):
         x_centers = 0.5 * (x_bins[:-1] + x_bins[1:])
         y_centers = 0.5 * (y_bins[:-1] + y_bins[1:])
         if kde:
-            # nn = x_centers.size * 2  # Double samples for KDE because smooth
-            # x_centers = np.linspace(x_bins.min(), x_bins.max(), nn)
-            # y_centers = np.linspace(y_bins.min(), y_bins.max(), nn)
-            # xx, yy = meshgrid(x_centers, y_centers, indexing='ij')
-            # coords = np.vstack((xx.flatten(), yy.flatten())).T
-            # data = np.vstack((x, y)).T
-            # hist = MegKDE(data, w, kde).evaluate(coords).reshape((nn, nn))
-            
             nn = x_centers.size * 2  # Double samples for KDE because smooth
             x_centers = np.linspace(x_bins.min(), x_bins.max(), nn)
             y_centers = np.linspace(y_bins.min(), y_bins.max(), nn)
             xx, yy = meshgrid(x_centers, y_centers, indexing='ij')
             coords = np.vstack((xx.flatten(), yy.flatten())).T
-            
-            print coords.shape
-            print xx.shape
-            print xx.flatten().shape
-            
+            # data = np.vstack((x, y)).T
+            # hist = MegKDE(data, w, kde).evaluate(coords).reshape((nn, nn))
             hist_kde, (x_centers_kde, y_centers_kde) = fastKDE.pdf(x,y)
-            
-            print hist_kde.shape
-            print x_centers_kde.shape
-            
             hist = interp2d(x_centers_kde, y_centers_kde, hist_kde, kind='linear', bounds_error=False, fill_value=0.)(x_centers, y_centers).reshape((nn, nn))
-            
             
         elif smooth:
             hist = gaussian_filter(hist, smooth, mode=self.parent._gauss_mode)


### PR DESCRIPTION
This is a first quick-and-dirty implementation of incorporating fastKDE (https://bitbucket.org/lbl-cascade/fastkde) to replace the slow KDE algorithm in place, as discussed in https://github.com/Samreay/ChainConsumer/issues/45#issuecomment-384279369. The dependence on the external package needs to be implemented in a clean way and tested are needed.