### PR TITLE
Removed double instance of lgreen from default colors list

### DIFF
--- a/chainconsumer/colors.py
+++ b/chainconsumer/colors.py
@@ -27,8 +27,8 @@ class Colors(object):
             "o": "orange", "y": "yellow", "a": "amber", "p": "purple",
             "e": "grey", "lg": "lgreen", "lb": "lblue"
         }
-        self.default_colors = ["blue", "green", "red", "purple", "yellow", "grey",
-                               "lblue", "magenta", "lgreen", "brown", "black", "orange"]
+        self.default_colors = ["blue", "lgreen", "red", "purple", "yellow", "grey",
+                               "lblue", "magenta", "green", "brown", "black", "orange"]
 
     def format(self, color):
         if isinstance(color, np.ndarray):

--- a/chainconsumer/colors.py
+++ b/chainconsumer/colors.py
@@ -27,7 +27,7 @@ class Colors(object):
             "o": "orange", "y": "yellow", "a": "amber", "p": "purple",
             "e": "grey", "lg": "lgreen", "lb": "lblue"
         }
-        self.default_colors = ["blue", "lgreen", "red", "purple", "yellow", "grey",
+        self.default_colors = ["blue", "green", "red", "purple", "yellow", "grey",
                                "lblue", "magenta", "lgreen", "brown", "black", "orange"]
 
     def format(self, color):


### PR DESCRIPTION
Noticed that lgreen appeared twice in the `default_colors` list. Edited this such that the first instance of lgreen is replaced by green. Could be re-ordered if you have a preference for lgreen first, I'm not fussed. 

I would also be happy to look at changing the default colours to be more colour-blind friendly -- having red and green together within the first three options probably isn't ideal.