### PR TITLE
New Feature: customizable Truth markers

### DIFF
--- a/src/chainconsumer/plotting/truth.py
+++ b/src/chainconsumer/plotting/truth.py
@@ -6,11 +6,27 @@ from ..truth import Truth
 
 def plot_truths(ax: Axes, truths: list[Truth], px: ColumnName | None = None, py: ColumnName | None = None) -> None:
     for truth in truths:
-        if px is not None:
-            val_x = truth.location.get(px)
-            if val_x is not None:
-                ax.axvline(val_x, **truth._kwargs)
-        if py is not None:
-            val_y = truth.location.get(py)
-            if val_y is not None:
-                ax.axhline(val_y, **truth._kwargs)
+        # DEFAULT PLOTTING STYLE
+        if truth.off_diagonal_marker is None:
+            for truth in truths:
+                if px is not None:
+                    val_x = truth.location.get(px)
+                    if val_x is not None:
+                        ax.axvline(val_x, **truth._kwargs)
+                if py is not None:
+                    val_y = truth.location.get(py)
+                    if val_y is not None:
+                        ax.axhline(val_y, **truth._kwargs)
+        # ALTERNATE PLOTTING STYLE
+        if truth.off_diagonal_marker:
+            if px is not None:
+                # Plot vertical line ONLY along diagonal
+                if py is None:
+                    val_x = truth.location.get(px)
+                    if val_x is not None:
+                        ax.axvline(val_x, **truth._kwargs)
+            # Plot specified markers on the off-diagonals
+            if py is not None:
+                val_x = truth.location.get(px)
+                val_y = truth.location.get(py)
+                ax.scatter(val_x, val_y, marker=truth.off_diagonal_marker, s=truth.off_diagonal_marker_size, c=truth._kwargs['c'], alpha=truth._kwargs['alpha'], zorder=truth._kwargs['zorder'])

--- a/src/chainconsumer/truth.py
+++ b/src/chainconsumer/truth.py
@@ -18,7 +18,9 @@ class Truth(BetterBase):
     line_style: str = Field(default="--", description="The style of the truth line")
     alpha: float = Field(default=1.0, description="The alpha of the truth line")
     zorder: int = Field(default=100, description="The zorder of the truth line")
-
+    off_diagonal_marker: str | None = Field(default=None, description="The truth marker style for the off-diagonal plots")
+    off_diagonal_marker_size: float = Field(default=100.0, description="The truth marker size for the off-diagonal plots")
+    
     @field_validator("location")
     @classmethod
     def _ensure_dict(cls, v):


### PR DESCRIPTION
Hi @Samreay, today I opened the Issue `Multi-truth marker styles #146` to propose a new feature.  I left a description there, and this morning I was a little stuck but I think I actually managed to figure out how to implement the change!  That said, I'm curious to hear if you like this idea!  And if you see it, do like it, and have a better idea of how to implement it, by all means go ahead and make some changes! :)

The main idea is that when adding the truth markers to the corner plots, the current implementation uses `axhline` and `axvline` to place lines in all subplots.  If I want to add _multiple_ truths to the plot, this adds what appears like "extraneous" truth solutions, and makes those plots very busy.

I wanted to be able to customize the markers in the bottom portion of the triangle, so I added two new arguments to the `Truth` class: `off_diagonal_marker` and `off_diagonal_marker_size` which allow the user to pass in both a marker style and marker size to `scatter()`.  These are then read in `truth.py` file in `plotting`.  If the user does not specify them, then the plot defaults to the style you had implemented before.  If the user does specify these values, then the bottom triangle subplots user scatter markers rather than horizontal/vertical lines to mark the truths.

Definitely take a look over it - you know your code better than I do! - and make sure I didn't accidentally break something somewhere else.  And of course, feel free to change any of this if you think there are better ways of doing it.

Also, below is a short code snippet that you can use to generate a quick example of a corner plot where you can toggle on/off these new features!


**Example code to demonstrate the new feature:**

```
import numpy as np
import pandas as pd

### Be sure to change this path to pull this edited version of chainconsumer wherever that is on your machine!
import sys
sys.path.append('./ChainConsumer/src/chainconsumer/')
from chainconsumer import Chain, ChainConsumer, Truth

### Let's inject two Gaussians:
injection = [[0,0,0], [8,-3,0]]

samples1 = np.random.multivariate_normal(np.array(injection[0]), np.array([[1,0,0],[0,1,0],[0,0,1]]), size=100000)
samples2 = np.random.multivariate_normal(np.array(injection[1]), np.array([[2,0.9,-1.1],[0.9,1,0],[-1.1,0,4]]), size=100000)

labels = [r'$x$', r'$y$', r'$z$']

pdsamples1 = pd.DataFrame(data = samples1,
                          columns = labels)
pdsamples2 = pd.DataFrame(data = samples2,
                          columns = labels)

c = ChainConsumer()

c.add_chain(Chain(samples=pdsamples1, name="mode 1"))
c.add_chain(Chain(samples=pdsamples2, name="mode 2"))

### Now plot the truths with the new marker features!
for inj in injection:
    c.add_truth(Truth(location=dict(zip(labels, inj)), color='k', alpha=1, off_diagonal_marker='+' , off_diagonal_marker_size=200))

c.plotter.plot();
```

